### PR TITLE
Add ClaimSnakQuantityValue

### DIFF
--- a/source/claim.ts
+++ b/source/claim.ts
@@ -18,7 +18,13 @@ export interface ClaimSnak {
 	readonly snaktype: string;
 }
 
-export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
+export type ClaimSnakValue = ClaimSnakStringValue | ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
+
+
+export interface ClaimSnakStringValue {
+	readonly type: 'string';
+	readonly value: string;
+}
 
 export interface ClaimSnakTimeValue {
 	readonly type: 'time';

--- a/source/claim.ts
+++ b/source/claim.ts
@@ -18,7 +18,7 @@ export interface ClaimSnak {
 	readonly snaktype: string;
 }
 
-export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue
+export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
 
 export interface ClaimSnakTimeValue {
 	readonly type: 'time';
@@ -29,6 +29,14 @@ export interface ClaimSnakTimeValue {
 		readonly precision: number;
 		readonly time: string;
 		readonly timezone: number;
+	};
+}
+
+export interface ClaimSnakQuantityValue {
+	readonly type: 'quantity';
+	readonly value: {
+		readonly amount: string;
+		readonly unit: number;
 	};
 }
 


### PR DESCRIPTION
The property P1082 used a quantity datatype for a claim snak value.

Example of a P1082 claim in Q517354:

`
P1082": [
{
"mainsnak": {
"snaktype": "value",
"property": "P1082",
"hash": "4f1f3e62f2880e880f730933892aa0b8c6086bcb",
"datavalue": {
"value": {
"amount": "+302",
"unit": "1"
},
"type": "quantity"
},
"datatype": "quantity"
},
"type": "statement",
"id": "Q517354$2112c207-47ed-2198-05f8-145690406deb",
"rank": "normal",
"references": []
},`

I added a type for ClaimSnakQuantityValue.