### PR TITLE
Fix pull request #15 (Add ClaimSnakStringValue, ClaimSnakQualtityValue)

### DIFF
--- a/source/claim.ts
+++ b/source/claim.ts
@@ -18,7 +18,11 @@ export interface ClaimSnak {
 	readonly snaktype: string;
 }
 
-export type ClaimSnakValue = ClaimSnakStringValue | ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
+export type ClaimSnakValue =
+       ClaimSnakEntityValue |
+       ClaimSnakQuantityValue |
+       ClaimSnakStringValue |
+       ClaimSnakTimeValue
 
 
 export interface ClaimSnakStringValue {

--- a/source/claim.ts
+++ b/source/claim.ts
@@ -18,7 +18,13 @@ export interface ClaimSnak {
 	readonly snaktype: string;
 }
 
-export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
+export type ClaimSnakValue = ClaimSnakStringValue | ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
+
+
+export interface ClaimSnakStringValue {
+	readonly type: 'string';
+	readonly value: string;
+}
 
 export interface ClaimSnakTimeValue {
 	readonly type: 'time';

--- a/source/claim.ts
+++ b/source/claim.ts
@@ -42,7 +42,7 @@ export interface ClaimSnakQuantityValue {
 	readonly type: 'quantity';
 	readonly value: {
 		readonly amount: string;
-		readonly unit: number;
+		readonly unit: string;
 	};
 }
 

--- a/source/claim.ts
+++ b/source/claim.ts
@@ -24,7 +24,6 @@ export type ClaimSnakValue =
        ClaimSnakStringValue |
        ClaimSnakTimeValue
 
-
 export interface ClaimSnakStringValue {
 	readonly type: 'string';
 	readonly value: string;

--- a/source/claim.ts
+++ b/source/claim.ts
@@ -18,7 +18,7 @@ export interface ClaimSnak {
 	readonly snaktype: string;
 }
 
-export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue
+export type ClaimSnakValue = ClaimSnakTimeValue | ClaimSnakEntityValue | ClaimSnakQuantityValue
 
 export interface ClaimSnakTimeValue {
 	readonly type: 'time';
@@ -29,6 +29,14 @@ export interface ClaimSnakTimeValue {
 		readonly precision: number;
 		readonly time: string;
 		readonly timezone: number;
+	};
+}
+
+export interface ClaimSnakQuantityValue {
+	readonly type: 'quantity';
+	readonly value: {
+		readonly amount: string;
+		readonly unit: number;
 	};
 }
 


### PR DESCRIPTION
Thanks for these types.

I've been using my own fork for a while which ammends the incorrect `type` on the `unit` property, and noticed that pull request #15 is still unmerged.

This pull request fixes that and should be ready to merge ClaimSnakStringValue, ClaimSnakQualtityValue into main. 