### PR TITLE
feat(claim): Add type ClaimSnakMonolingualTextValue

### DIFF
--- a/source/claim.ts
+++ b/source/claim.ts
@@ -20,6 +20,7 @@ export interface ClaimSnak {
 
 export type ClaimSnakValue =
        ClaimSnakEntityValue |
+       ClaimSnakMonolingualTextValue |
        ClaimSnakQuantityValue |
        ClaimSnakStringValue |
        ClaimSnakTimeValue
@@ -55,6 +56,14 @@ export interface ClaimSnakEntityValue {
 		readonly id: string;
 		readonly 'numeric-id': number;
 		readonly 'entity-type': string;
+	};
+}
+
+export interface ClaimSnakMonolingualTextValue {
+	readonly type: 'monolingualtext';
+	readonly value: {
+		readonly text: string;
+		readonly language: string;
 	};
 }
 


### PR DESCRIPTION
Adds a new snak value type for a `monolingualtext` value

For some reason I can find very little documenation on this snak value type, despite it being in frequent use throughout WikiData.

It's briefly mentioned without schema reference details [here](https://www.wikidata.org/wiki/Help:Data_type#monolingualtext)

Here's an example value from the WikiData API result for [Q341600](https://www.wikidata.org/w/api.php?action=wbgetentities&ids=Q341600&format=json)

```json
{
  "mainsnak": {
    "snaktype": "value",
    "property": "P1843",
    "hash": "d96cc2ab17268cc3e473c7e1a1104a6f50d07d32",
    "datavalue": {
      "value": {
        "text": "Acker-Kratzdistel",
        "language": "de"
      },
      "type": "monolingualtext"
    },
    "datatype": "monolingualtext"
  }
}
``` 